### PR TITLE
Handle the clear_output spec

### DIFF
--- a/src/Display.jsx
+++ b/src/Display.jsx
@@ -21,10 +21,21 @@ export default class Display extends React.Component {
   };
 
   render() {
+    // Handle the clear_output spec by only display that which comes after
+    // the last clear_output
+    let outputs = this.props.outputs;
+    const fromIndex = outputs.findLastIndex(
+      output => output.get('output_type') === 'clear_output'
+    );
+    if(fromIndex !== -1) {
+      // Note: when clear_output is the last element, this is an empty array
+      outputs = outputs.slice(fromIndex + 1);
+    }
+
     return (
       <div className='cell_display'>
       {
-        this.props.outputs.map((output, index) =>
+        outputs.map((output, index) =>
           <Output output={output} key={index}
                   displayOrder={this.props.displayOrder}
                   transforms={this.props.transforms}


### PR DESCRIPTION
It just dawned on me how to implement [`clear_output`](http://jupyter-client.readthedocs.org/en/latest/messaging.html#clear-output), at least partially.

Note that `wait` is ignored from the spec.