### PR TITLE
Remove electron-mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "npm run build:es5",
     "build:es5": "babel src --out-dir lib/ --source-maps",
     "build:watch": "babel src --watch --out-dir lib/ --source-maps",
-    "test": "electron-mocha --renderer --compilers js:babel-core/register 'test/**/*.@(js|jsx)'",
+    "test": "mocha --compilers js:babel-core/register 'test/**/*.@(js|jsx)'",
     "test:watch": "npm run test -- --watch",
     "clean": "rimraf lib/*"
   },
@@ -53,7 +53,6 @@
     "babel-preset-react": "^6.3.13",
     "chai": "^3.4.1",
     "chai-immutable": "^1.5.4",
-    "electron-mocha": "^1.2.2",
     "electron-prebuilt": "^0.36.3",
     "eslint": "^2.8.0",
     "eslint-config-airbnb": "^8.0.0",


### PR DESCRIPTION
`electron-mocha` was outdated and resulted in a test failure.

JK, why are we using electron-mocha in these tests in the first place? Anyways, I removed it because I don't see a reason for it but let me know if I am missing something.