### PR TITLE
Togglable

### DIFF
--- a/src/TogglableDisplay.jsx
+++ b/src/TogglableDisplay.jsx
@@ -5,21 +5,21 @@ import { transforms, displayOrder } from 'transformime-react';
 
 import Display from './Display';
 
-export default function ToggleableDisplay(props) {
+export default function TogglableDisplay(props) {
   const style = { display: props.isHidden ? 'none' : 'block' };
   return (
     <Display {...props} style={style}/>
   );
 }
 
-ToggleableDisplay.propTypes = {
+TogglableDisplay.propTypes = {
   displayOrder: React.PropTypes.instanceOf(Immutable.List),
   outputs: React.PropTypes.instanceOf(Immutable.List),
   transforms: React.PropTypes.instanceOf(Immutable.Map),
   isHidden: React.PropTypes.bool,
 };
 
-ToggleableDisplay.defaultProps = {
+TogglableDisplay.defaultProps = {
   transforms,
   displayOrder,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,6 @@
 import Display from './Display';
 import TogglableDisplay from './TogglableDisplay';
 
+export default Display;
+
 export { Display, TogglableDisplay };

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
 import Display from './Display';
-import ToggleableDisplay from './ToggleableDisplay';
+import TogglableDisplay from './TogglableDisplay';
 
-export { Display, ToggleableDisplay };
+export { Display, TogglableDisplay };

--- a/test/TogglableDisplay_spec.jsx
+++ b/test/TogglableDisplay_spec.jsx
@@ -11,18 +11,18 @@ import {
   createRenderer
 } from 'react-addons-test-utils';
 
-import ToggleableDisplay from '../src/ToggleableDisplay';
+import TogglableDisplay from '../src/TogglableDisplay';
 
-describe('ToggleableDisplay', () => {
+describe('TogglableDisplay', () => {
   it('does not display when status is hidden', () => {
     const renderer = createRenderer();
-    renderer.render(<ToggleableDisplay isHidden={true} />);
+    renderer.render(<TogglableDisplay isHidden={true} />);
     const component = renderer.getRenderOutput();
     expect(component.props.style.display).to.equal('none');
   });
   it('displays status when it is not hidden', () => {
     const renderer = createRenderer();
-    renderer.render(<ToggleableDisplay isHidden={false} />);
+    renderer.render(<TogglableDisplay isHidden={false} />);
     const component = renderer.getRenderOutput();
     expect(component.props.style.display).to.equal('block');
   });


### PR DESCRIPTION
[Togglable](https://en.wiktionary.org/wiki/togglable) is the primary spelling, [Toggleable](https://en.wiktionary.org/wiki/toggleable#English) is the alternate. I've switched it to the primary here.

Additionally, I made sure the `default` export was still here to keep us backwards compatible.