### PR TITLE
Fix output hiding

### DIFF
--- a/src/TogglableDisplay.jsx
+++ b/src/TogglableDisplay.jsx
@@ -6,10 +6,13 @@ import { transforms, displayOrder } from 'transformime-react';
 import Display from './Display';
 
 export default function TogglableDisplay(props) {
-  const style = { display: props.isHidden ? 'none' : 'block' };
-  return (
-    <Display {...props} style={style}/>
-  );
+  if (!props.isHidden) {
+    return (
+      <Display {...props}/>
+    );
+  } else {
+    return null;
+  }
 }
 
 TogglableDisplay.propTypes = {

--- a/test/TogglableDisplay_spec.jsx
+++ b/test/TogglableDisplay_spec.jsx
@@ -18,12 +18,12 @@ describe('TogglableDisplay', () => {
     const renderer = createRenderer();
     renderer.render(<TogglableDisplay isHidden={true} />);
     const component = renderer.getRenderOutput();
-    expect(component.props.style.display).to.equal('none');
+    expect(component).to.be.null;
   });
   it('displays status when it is not hidden', () => {
     const renderer = createRenderer();
     renderer.render(<TogglableDisplay isHidden={false} />);
     const component = renderer.getRenderOutput();
-    expect(component.props.style.display).to.equal('block');
+    expect(component).to.not.be.null;
   });
 });


### PR DESCRIPTION
While integrating this with nteract, I discovered that using `display: none` doesn't actually do anything. I dunno why and I was too frustrated with this to investigate further (ha!).

Anyway, looking at the React docs, the recommendation is to return no component at all as opposed to a styled component.